### PR TITLE
Fix failing deploy in Angular 16

### DIFF
--- a/libs/ngx-aws-deploy/src/lib/deploy/index.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/index.ts
@@ -81,7 +81,8 @@ export default createBuilder(
       context.logger.info(`✔ Build Completed`);
     }
     if (buildResult.success) {
-      const filesPath = buildResult.outputPath as string;
+      const filesPath = buildResult.outputPath ?? buildResult.outputs[0].path;
+
       const files = getFiles(filesPath);
 
       if (files.length === 0) {


### PR DESCRIPTION
outputPath property has been removed in Angular 16. outputs should be used to resolve build outputPath.